### PR TITLE
allow queries by wos, scp, or url

### DIFF
--- a/R/alm_events.R
+++ b/R/alm_events.R
@@ -8,16 +8,18 @@
 #' @param doi Digital object identifier for an article in PLoS Journals (character)
 #' @param pmid PubMed object identifier (numeric)
 #' @param pmcid PubMed Central object identifier (numeric)
-#' @param mendeley_uuid Mendeley object identifier (character)
+#' @param wos Web of Science identifier (character)
+#' @param scp Scopus identifier (character)
+#' @param url Canonical URL (character)
 #' @param source_id (character) Name of source to get ALM information for. One source only.
 #'    You can get multiple sources via a for loop or lapply-type call.
 #' @param publisher_id (character) Metrics for articles by a given publisher, using the Crossref
 #'    \code{member_id}.
-#' @param compact (logical) Whether to make output compact or not. If TRUE (default), remove 
-#'    empty sources. 
-#' @param key (character) Your API key, either enter, or loads from .Rprofile. Only required for 
+#' @param compact (logical) Whether to make output compact or not. If TRUE (default), remove
+#'    empty sources.
+#' @param key (character) Your API key, either enter, or loads from .Rprofile. Only required for
 #'    PKP source, not the others.
-#' @param url API endpoint, defaults to http://alm.plos.org/api/v3/articles (character)
+#' @param api_url API endpoint, defaults to http://alm.plos.org/api/v3/articles (character)
 #' @param ... optional additional curl options (debugging tools mostly)
 #' @details You can only supply one of the parmeters doi, pmid, pmcid, and mendeley.
 #'
@@ -68,14 +70,14 @@
 #' out[[1]]
 #' out[[2]]
 #' out[[1]][["figshare"]]$events
-#' 
-#' # Many pmcid's 
+#'
+#' # Many pmcid's
 #' out <- alm_events(pmcid=c(212692,2082661))
 #' names(out)
 #' out['212692']
-#' 
+#'
 #' # Many pmid's
-#' out <- alm_events(pmid = c(19300479, 19390606, 19343216)) 
+#' out <- alm_events(pmid = c(19300479, 19390606, 19343216))
 #' names(out)
 #' out['19390606']
 #'
@@ -84,7 +86,7 @@
 #'
 #' # Specify two specific sources
 #' ## You have to do so through lapply, or similar approach
-#' lapply(c("crossref","twitter"), 
+#' lapply(c("crossref","twitter"),
 #'    function(x) alm_events(doi="10.1371/journal.pone.0035869", source_id=x))
 #'
 #' # Figshare data
@@ -92,16 +94,16 @@
 #'
 #' # Datacite data
 #' alm_events("10.1371/journal.pone.0012090", source_id='datacite')
-#' 
+#'
 #' # Reddit data
 #' alm_events("10.1371/journal.pone.0015552", source_id='reddit')
-#' 
+#'
 #' # Wordpress data
 #' alm_events("10.1371/journal.pcbi.1000361", source_id='wordpress')
-#' 
+#'
 #' # Articlecoverage data
 #' alm_events(doi="10.1371/journal.pmed.0020124", source_id='articlecoverage')
-#' 
+#'
 #' # Articlecoveragecurated data
 #' headfoo <- function(x) head(x$articlecoveragecurated$events)
 #' headfoo(alm_events(doi="10.1371/journal.pone.0088278", source_id='articlecoveragecurated'))
@@ -113,11 +115,11 @@
 #'            '10.1371/journal.pbio.0040020')
 #' res <- alm_events(doi = dois, source_id='f1000')
 #' res[[3]]
-#' 
+#'
 #' # by source_id only
 #' alm_events(source_id = "crossref")
 #' alm_events(source_id = "reddit")
-#' 
+#'
 #' # by publisher_id only
 #' alm_events(publisher_id = 340)
 #' }
@@ -125,49 +127,49 @@
 #' @examples \dontest{
 #' # Crossref article data
 #' # You need to get an API key first, and pass in a different URL
-#' url <- "http://alm.labs.crossref.org/api/v3/articles"
+#' api_url <- "http://alm.labs.crossref.org/api/v3/articles"
 #' key <- getOption("crossrefalmkey")
 #' # With wikipedia data
-#' alm_events(doi='10.1371/journal.pone.0086859', url = url, key = key)
+#' alm_events(doi='10.1371/journal.pone.0086859', api_url = api_url, key = key)
 #' # With facebook data
-#' alm(doi='10.1080/15459624.2013.816432', url = url, key = key)
+#' alm(doi='10.1080/15459624.2013.816432', api_url = api_url, key = key)
 #' alm_events(doi='10.1080/15459624.2013.816432', url = url, key = key)
 #' # With CrossRef citation data - no events data for citations though...
-#' alme(doi='10.1021/cr400135x', url = url, key = key)
-#' alm_events(doi='10.1021/cr400135x', url = url, key = key)
+#' alme(doi='10.1021/cr400135x', api_url = api_url, key = key)
+#' alm_events(doi='10.1021/cr400135x', api_url = api_url, key = key)
 #'
 #' # Public Knowledge Project article data
 #' # You need to get an API key first, and pass in a different URL
-#' url <- 'http://pkp-alm.lib.sfu.ca/api/v3/articles'
-#' alm_events(doi='10.3402/gha.v7.23554', url = url, key = getOption("pkpalmkey"))
+#' api_url <- 'http://pkp-alm.lib.sfu.ca/api/v3/articles'
+#' alm_events(doi='10.3402/gha.v7.23554', api_url = api_url, key = getOption("pkpalmkey"))
 #'
 #' # Copernicus publishers article data
 #' # You need to get an API key first, and pass in a different URL
-#' url <- 'http://metricus.copernicus.org/api/v3/articles'
-#' alm_events(doi='10.5194/acpd-14-8287-2014', url = url, key = getOption("copernicusalmkey"))
+#' api_url <- 'http://metricus.copernicus.org/api/v3/articles'
+#' alm_events(doi='10.5194/acpd-14-8287-2014', api_url = api_url, key = getOption("copernicusalmkey"))
 #' }
 
-alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
-  source_id = NULL, publisher_id = NULL, compact = TRUE, key = NULL, 
-  url='http://alm.plos.org/api/v5/articles', ...)
+alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, wos = NULL, scp = NULL, url = NULL,
+  source_id = NULL, publisher_id = NULL, compact = TRUE, key = NULL,
+  api_url='http://alm.plos.org/api/v5/articles', ...)
 {
-	id <- almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, mendeley_uuid=mendeley_uuid, source_id=source_id, publisher_id=publisher_id))
-	if(length(id)>1) stop("Only supply one of: doi, pmid, pmcid, mendeley_uuid, source_id, or publisher_id")
+	id <- almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, wos=wos, scp=scp, url=url, source_id=source_id, publisher_id=publisher_id))
+	if(length(id)>1) stop("Only supply one of: doi, pmid, pmcid, wos, scp, url, source_id, or publisher_id")
 	# key <- getkey(key)
 	if(length(source_id) > 1) stop("You can only supply one source_id")
 	if(length(publisher_id) > 1) stop("You can only supply one publisher_id")
 
 	parse_events <- function() {
-	  args <- almcompact(list(api_key = key, info = 'detail', source_id = source_id, 
+	  args <- almcompact(list(api_key = key, info = 'detail', source_id = source_id,
                             publisher_id=publisher_id, type = idtype(names(id))))
-		if(length(almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, mendeley_uuid=mendeley_uuid))) == 0){
-      if(length(id) == 0) stop("Please provide one of: doi, pmid, pmcid, mendeley_uuid, source_id, or publisher_id")
-      ttt <- alm_GET(url, args, ...)
+		if(length(almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, wos=wos, url=url))) == 0){
+      if(length(id) == 0) stop("Please provide one of: doi, pmid, pmcid, wos, scp, url, source_id, or publisher_id")
+      ttt <- alm_GET(api_url, args, ...)
       events <- lapply(ttt$data, function(x) x$sources)
 		} else {
 		  if(length(id[[1]])==1){
 		    if(names(id) == "doi") id <- gsub("/", "%2F", id)
-		    ttt <- alm_GET(url, c(args, ids = id[[1]]), ...)
+		    ttt <- alm_GET(api_url, c(args, ids = id[[1]]), ...)
 		    events <- lapply(ttt$data, function(x) x$sources)
 		  } else
 		    if(length(id[[1]])>1){
@@ -176,19 +178,19 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
 		        idsplit <- slice(id[[1]], 50)
 		        repeatit <- function(y) {
 		          id2 <- if(names(id) == "doi") paste(sapply(y, function(x) gsub("/", "%2F", x)), collapse=",") else paste(id[[1]], collapse=",")
-		          alm_GET(url, c(args, ids = id2), ...)
+		          alm_GET(api_url, c(args, ids = id2), ...)
 		        }
 		        temp <- lapply(idsplit, repeatit)
 		        ttt <- do.call(c, lapply(temp, "[[", "data"))
 		        events <- unname(lapply(ttt, function(x) x$sources))
 		      } else {
 		        id2 <- concat_ids(id)
-		        ttt <- alm_GET(x = url, y = c(args, ids = id2), ...)
+		        ttt <- alm_GET(x = api_url, y = c(args, ids = id2), ...)
 		        events <- lapply(ttt$data, function(x) x$sources)
 		      }
 		    }
 		}
-		
+
 		# get juse the events data
     # events <- lapply(ttt$data, function(x) x$sources)
 
@@ -291,8 +293,8 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
 						}
 					}
 				} else if(y$name == "pubmed"){
-					if(length(y$events)==0){paste(sorry)} else { 
-					  eventspar <- ldply(y$events, function(x) data.frame(x[c("event","event_url")])) 
+					if(length(y$events)==0){paste(sorry)} else {
+					  eventspar <- ldply(y$events, function(x) data.frame(x[c("event","event_url")]))
             list(events_url=y$events_url, events=eventspar, events_csl=y$events_csl)
 				  }
 				} else if(y$name == "facebook"){
@@ -366,7 +368,7 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
 					if(length(y$events)==0){paste(sorry)} else
 						{
 						  csl <- ldply(y$events_csl, parse_csl)
-						  list(events_url=y$events_url, events=y$events, events_csl=csl) 
+						  list(events_url=y$events_url, events=y$events, events_csl=csl)
 						}
 				} else if(y$name == "wos"){
 					if(length(y$events)==0){paste(sorry)} else
@@ -462,7 +464,7 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
 				} else if(y$name == "reddit"){
 				  if(length(y$events)==0){paste(sorry)} else
 				  {
-            eventsdat <- 
+            eventsdat <-
               lapply(y$events, function(b){
                 tmp <- b$event[ !names(b$event) %in% c('selftext_html','selftext') ]
                 tmp[sapply(tmp, length)==0] <- NA
@@ -502,9 +504,9 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
 				    ev <- do.call(rbind.fill, lapply(y$events, function(b){
 				      tmp <- b$event
 				      tmp[sapply(tmp, length)==0|sapply(tmp, is.null)] <- NA
-				      data.frame(tmp, 
-				                 event_time=b$event_time, 
-				                 event_url=if(!is.null(b$event_url)) b$event_url else NA, 
+				      data.frame(tmp,
+				                 event_time=b$event_time,
+				                 event_url=if(!is.null(b$event_url)) b$event_url else NA,
                          stringsAsFactors = FALSE)
 				    }))
 				    csl <- ldply(y$events_csl, parse_csl)
@@ -517,8 +519,8 @@ alm_events <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NU
                 tmp <- b$event
                 tmp[sapply(tmp, length)==0] <- NA
                 tmp$replies <- NULL
-                list(comment=data.frame(tmp, 
-                           event_time=b$event_time, 
+                list(comment=data.frame(tmp,
+                           event_time=b$event_time,
                            event_url=if(!is.null(b$event_url)) b$event_url else NA, stringsAsFactors = FALSE),
                      replies=b$event$replies)
               })
@@ -575,7 +577,7 @@ parse_csl <- function(z){
   data.frame(authors=aut,
              title=z$title,
              container_title=z$`container-title`,
-             issued=try_date_parts(z$issued), 
+             issued=try_date_parts(z$issued),
              url=z$url,
              type=z$type,
              stringsAsFactors = FALSE)

--- a/R/alm_ids.R
+++ b/R/alm_ids.R
@@ -12,16 +12,16 @@
 #' @references See a tutorial/vignette for alm at
 #' \url{http://ropensci.org/tutorials/alm_tutorial.html}
 
-alm_ids <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL, info = "totals",
+alm_ids <- function(doi = NULL, pmid = NULL, pmcid = NULL, wos = NULL, scp = NULL, url = NULL, info = "totals",
   source_id = NULL, publisher_id = NULL, key = NULL, total_details = FALSE, sum_metrics = NULL, sleep = 0,
-	url = 'http://alm.plos.org/api/v5/articles', ...)
+	api_url = 'http://alm.plos.org/api/v5/articles', ...)
 {
 	# key <- getkey(key)
   info <- match.arg(info, c("summary","totals","detail"))
   if(!is.null(doi)) doi <- doi[!grepl("image", doi)] # remove any DOIs of images
-	id <- almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, mendeley_uuid=mendeley_uuid, source_id=source_id, publisher_id=publisher_id))
-	if(length(id) == 0) stop("Supply one of: doi, pmid, pmcid, mendeley_uuid, source_id, or publisher_id")
-	if(length(id) > 1) stop("Only supply one of: doi, pmid, pmcid, mendeley_uuid, source_id, or publisher_id")
+	id <- almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, wos=wos, scp=scp, url=url, source_id=source_id, publisher_id=publisher_id))
+	if(length(id) == 0) stop("Supply one of: doi, pmid, pmcid, wos, scp, url, source_id, or publisher_id")
+	if(length(id) > 1) stop("Only supply one of: doi, pmid, pmcid, wos, scp, url, source_id, or publisher_id")
   if(length(source_id) > 1) stop("You can only supply one source_id")
 	if(length(publisher_id) > 1) stop("You can only supply one publisher_id")
 
@@ -29,13 +29,13 @@ alm_ids <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
     info2 <- switch(info, totals=NULL, detail='detail', summary='summary')
 		if(!is.null(sum_metrics)) info <- info2 <- 'detail'
 		args <- almcompact(list(api_key = key, info = info2, source_id = source_id, publisher_id = publisher_id, type = idtype(names(id))))
-		if(length(almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, mendeley_uuid=mendeley_uuid))) == 0){
-		  if(length(id) == 0) stop("Please provide one of: doi, pmid, pmcid, mendeley_uuid, source_id, or publisher_id")
-		  tt <- alm_GET(url, args, ...)
+		if(length(almcompact(list(doi=doi, pmid=pmid, pmcid=pmcid, wos=wos, scp=scp, url=url))) == 0){
+		  if(length(id) == 0) stop("Please provide one of: doi, pmid, pmcid, wos, scp, url, source_id, or publisher_id")
+		  tt <- alm_GET(api_url, args, ...)
     } else {
 			if(length(id[[1]])==1){
 				if(names(id) == "doi") id <- gsub("/", "%2F", id)
-				tt <- alm_GET(x = url, y = c(args, ids = id[[1]]), ...)
+				tt <- alm_GET(x = api_url, y = c(args, ids = id[[1]]), ...)
 			} else
 			{
 				if(length(id[[1]])>1){
@@ -49,25 +49,25 @@ alm_ids <- function(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
 							{
 								id2 <- paste(id[[1]], collapse=",")
 							}
-							tt <- alm_GET(url, c(args, ids = id2), sleep=sleep, ...)
+							tt <- alm_GET(api_url, c(args, ids = id2), sleep=sleep, ...)
 						}
 						temp <- lapply(idsplit, repeatit)
             justdat <- do.call(c, unname(lapply(temp, "[[", "data")))
             tt <- c(temp[[1]][ !names(temp[[1]]) == "data" ], data=list(justdat))
 					} else {
 					  id2 <- id2 <- concat_ids(id)
-						tt <- alm_GET(url, c(args, ids = id2), ...)
+						tt <- alm_GET(api_url, c(args, ids = id2), ...)
 					}
 				}
 			}
     }
-		
+
     if(info=="summary"){
 		  if(length(id[[1]]) > 1 | !is.null(source_id) | !is.null(publisher_id)){
 		    restmp <- lapply(tt$data, getsummary)
         names(restmp) <- vapply(tt$data, function(x) x$doi, character(1))
-		  } else { 
-        restmp <- getsummary(tt$data[[1]]) 
+		  } else {
+        restmp <- getsummary(tt$data[[1]])
 		  }
       list(meta=metadf(tt), data=restmp)
     } else {

--- a/man/alm_events.Rd
+++ b/man/alm_events.Rd
@@ -4,9 +4,9 @@
 \alias{alm_events}
 \title{Retrieve PLoS article-level metrics (ALM) events.}
 \usage{
-alm_events(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
+alm_events(doi = NULL, pmid = NULL, pmcid = NULL, wos = NULL, scp = NULL, url = NULL,
   source_id = NULL, publisher_id = NULL, compact = TRUE, key = NULL,
-  url = "http://alm.plos.org/api/v5/articles", ...)
+  api_url = "http://alm.plos.org/api/v5/articles", ...)
 }
 \arguments{
 \item{doi}{Digital object identifier for an article in PLoS Journals (character)}
@@ -15,7 +15,11 @@ alm_events(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
 
 \item{pmcid}{PubMed Central object identifier (numeric)}
 
-\item{mendeley_uuid}{Mendeley object identifier (character)}
+\item{wos}{Web of Science identifier (character)}
+
+\item{scp}{Scopus identifier (character)}
+
+\item{url}{Canonical URL (character)}
 
 \item{source_id}{(character) Name of source to get ALM information for. One source only.
 You can get multiple sources via a for loop or lapply-type call.}
@@ -29,7 +33,7 @@ empty sources.}
 \item{key}{(character) Your API key, either enter, or loads from .Rprofile. Only required for
 PKP source, not the others.}
 
-\item{url}{API endpoint, defaults to http://alm.plos.org/api/v3/articles (character)}
+\item{api_url}{API endpoint, defaults to http://alm.plos.org/api/v3/articles (character)}
 
 \item{...}{optional additional curl options (debugging tools mostly)}
 }

--- a/man/alm_ids.Rd
+++ b/man/alm_ids.Rd
@@ -4,10 +4,10 @@
 \alias{alm_ids}
 \title{Retrieve PLoS article-level metrics (ALM).}
 \usage{
-alm_ids(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
+alm_ids(doi = NULL, pmid = NULL, pmcid = NULL, wos = NULL, scp = NULL, url=NULL,
   info = "totals", source_id = NULL, publisher_id = NULL, key = NULL,
   total_details = FALSE, sum_metrics = NULL, sleep = 0,
-  url = "http://alm.plos.org/api/v5/articles", ...)
+  api_url = "http://alm.plos.org/api/v5/articles", ...)
 }
 \arguments{
 \item{doi}{Digital object identifier for an article in PLoS Journals (character)}
@@ -16,7 +16,11 @@ alm_ids(doi = NULL, pmid = NULL, pmcid = NULL, mendeley_uuid = NULL,
 
 \item{pmcid}{PubMed Central object identifier (numeric)}
 
-\item{mendeley_uuid}{Mendeley object identifier (character)}
+\item{wos}{Web of Science identifier (character)}
+
+\item{scp}{Scopus identifier (character)}
+
+\item{url}{Canonical URL (character)}
 
 \item{info}{One of totals, summary, or detail (default totals + sum_metrics data in a list).
      Not specifying anything (the default) returns data.frame of totals across
@@ -47,7 +51,7 @@ articles published since May 2014.}
 \item{sleep}{Set a sleep time (in seconds). Only used for large calls where you may be in danger
 of upsetting the server gods, can you say 504 error?}
 
-\item{url}{API endpoint, defaults to http://alm.plos.org/api/v5/articles (character)}
+\item{api_url}{API endpoint, defaults to http://alm.plos.org/api/v5/articles (character)}
 
 \item{...}{optional additional curl options (debugging tools mostly)}
 }
@@ -59,14 +63,14 @@ This is the main function to search the PLoS ALM (article-level metrics) API.
 See details for more information.
 }
 \details{
-You can only supply one of the parmeters doi, pmid, pmcid, and mendeley; and you
+You can only supply one of the parmeters doi, pmid, pmcid, wos, scp or url; and you
 must supply one of them. Query for as many articles at a time as you like. Though queries
 are broken up in to smaller bits of 50 identifiers at a time. If you supply days, months and/or
 year parameters, days takes precedence over months and year.
 }
 \examples{
 \dontrun{
-# The default call with either doi, pmid, pmcid, or mendeley without specifying
+# The default call with either doi, pmid, pmcid, wos, scp or url without specifying
 # an argument for info
 alm_ids(doi="10.1371/journal.pone.0029797")
 
@@ -84,8 +88,14 @@ alm_ids(pmid=22590526)
 # A single PubMed Central ID (pmcid)
 alm_ids(pmcid=212692, info='summary')
 
-# A single Mendeley UUID (mendeley)
-alm_ids(mendeley_uuid="1d7e7f09-c59b-364b-8c39-a7686f0e9fa0")
+# A single Web of Science ID (wos)
+alm_ids(wos="000268452400005")
+
+# A single Scopus ID (scp)
+alm_ids(scp="68049122102")
+
+# A single canonical URL (url)
+alm_ids(url="http://www.plosmedicine.org/article/info:doi/10.1371/journal.pmed.1000097")
 
 # Provide more than one DOI
 dois <- c('10.1371/journal.pone.0001543','10.1371/journal.pone.0040117',


### PR DESCRIPTION
The Lagotto v5 API for works supports the following identifiers: doi, pmid, pmcid, wos, scp, url, where `wos` is the Web of Science id, `scp` is the Scopus id, and url is the canonical URL stored internally. This is a recent change, source code here: https://github.com/articlemetrics/lagotto/blob/master/app/controllers/api/v5/works_controller.rb#L17

Support for queries by `mendeley_uuid` has been removed, since the uuid changes frequently.

Two examples of queries by these new identifiers:
* http://alm.plos.org/api/v5/articles?ids=68049122102&type=scp
* http://software.lagotto.io/api/v5/articles?ids=https://github.com/najoshi/sickle&type=url

Current use case is to analyse the metrics for a collection of software repos. More info at https://github.com/mfenner/software-analysis. 

Because of the new `url` parameter for queries, the `url` parameter for `alm_ids` and `alm_events` has been renamed to `api_url`.